### PR TITLE
docs: minimal README tweaks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Description: A companion package to the testthat package that saves
     development time by helping you rerun only the tests that have failed
     during the last run.
 License: MIT + file LICENSE
-URL: https://github.com/krlmlr/lazytest, https://krlmlr.github.io/lazytest
+URL: https://github.com/krlmlr/lazytest, https://cynkra.github.io/lazytest/
 BugReports: https://github.com/krlmlr/lazytest/issues
 Imports: 
     brio,

--- a/README.Rmd
+++ b/README.Rmd
@@ -28,13 +28,16 @@ library(lazytest)
 ```
 
 The goal of lazytest is to save development time by helping you rerun only the tests that have failed during the last run.
-It integrates tightly with the testthat package and provides the `lazytest_local()` function, a drop-in replacement for `testthat::test_local()`, that memoizes the tests that have failed and runs only those tests in subsequent runs.
-If all active tests have succeeded, the entire test suite is run in a second pass.
+It integrates tightly with the testthat package and provides the `lazytest_local()` function, a drop-in replacement for `testthat::test_local()`, that 
 
+- memoizes which tests have failed;
+- runs only those tests in subsequent runs.
+
+If all active tests have succeeded, the entire test suite is run in a second pass.
 
 ## Usage
 
-Call `lazytest_local()` in lieu of `testthat::test_local()` or `devtools::test()`:
+Call `lazytest_local()` instead of `testthat::test_local()` or `devtools::test()`:
 
 ```{r, eval = FALSE}
 lazytest::lazytest_local()
@@ -54,9 +57,15 @@ In the next call, if `.lazytest` exists, it is consulted, and a suitable `filter
 When all tests have passed and not all tests were run, a second call to `testthat::test_local()` is initiated, to make sure that no failures have been introduced in the meantime.
 
 
-## Installation
+## Installation and optional setup
 
-You can install the development version of lazytest like so:
+You can install the development version of lazytest from [cynkra R-universe](https://cynkra.r-universe.dev/):
+
+``` r
+install.packages('lazytest', repos = c('https://cynkra.r-universe.dev', 'https://cloud.r-project.org'))
+```
+
+Or from GitHub:
 
 ``` r
 pak::pak("krlmlr/lazytest")

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <pre class='chroma'>
 <span><span class='kr'><a href='https://rdrr.io/r/base/library.html'>library</a></span><span class='o'>(</span><span class='nv'><a href='https://github.com/krlmlr/lazytest'>lazytest</a></span><span class='o'>)</span></span></pre>
 
-The goal of lazytest is to save development time by helping you rerun only the tests that have failed during the last run. It integrates tightly with the testthat package and provides the [`lazytest_local()`](https://rdrr.io/pkg/lazytest/man/lazytest_local.html) function, a drop-in replacement for [`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html), that
+The goal of lazytest is to save development time by helping you rerun only the tests that have failed during the last run. It integrates tightly with the testthat package and provides the [`lazytest_local()`](https://cynkra.github.io/lazytest/reference/lazytest_local.html) function, a drop-in replacement for [`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html), that
 
 - memoizes which tests have failed;
 - runs only those tests in subsequent runs.
@@ -20,16 +20,16 @@ If all active tests have succeeded, the entire test suite is run in a second pas
 
 ## Usage
 
-Call [`lazytest_local()`](https://rdrr.io/pkg/lazytest/man/lazytest_local.html) instead of [`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html) or [`devtools::test()`](https://devtools.r-lib.org/reference/test.html):
+Call [`lazytest_local()`](https://cynkra.github.io/lazytest/reference/lazytest_local.html) instead of [`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html) or [`devtools::test()`](https://devtools.r-lib.org/reference/test.html):
 
 <pre class='chroma'>
-<span><span class='nf'>lazytest</span><span class='nf'>::</span><span class='nf'><a href='https://rdrr.io/pkg/lazytest/man/lazytest_local.html'>lazytest_local</a></span><span class='o'>(</span><span class='o'>)</span></span></pre>
+<span><span class='nf'>lazytest</span><span class='nf'>::</span><span class='nf'><a href='https://cynkra.github.io/lazytest/reference/lazytest_local.html'>lazytest_local</a></span><span class='o'>(</span><span class='o'>)</span></span></pre>
 
 The package also provides RStudio add-ins that run the tests in a new terminal. Unfortunately, the “Test package” command is hard-wired to [`devtools::test()`](https://devtools.r-lib.org/reference/test.html), and there seems to be no way to customize it or hook into it.
 
 ## How does it work?
 
-[`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html) returns an object from which the tests that have failed can be retrieved. [`lazytest_local()`](https://rdrr.io/pkg/lazytest/man/lazytest_local.html) wraps this function. If tests have failed, a file named `.lazytest` is written in the package directory. In the next call, if `.lazytest` exists, it is consulted, and a suitable `filter` argument is constructed and passed to [`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html).
+[`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html) returns an object from which the tests that have failed can be retrieved. [`lazytest_local()`](https://cynkra.github.io/lazytest/reference/lazytest_local.html) wraps this function. If tests have failed, a file named `.lazytest` is written in the package directory. In the next call, if `.lazytest` exists, it is consulted, and a suitable `filter` argument is constructed and passed to [`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html).
 
 When all tests have passed and not all tests were run, a second call to [`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html) is initiated, to make sure that no failures have been introduced in the meantime.
 

--- a/README.md
+++ b/README.md
@@ -11,26 +11,36 @@
 <pre class='chroma'>
 <span><span class='kr'><a href='https://rdrr.io/r/base/library.html'>library</a></span><span class='o'>(</span><span class='nv'><a href='https://github.com/krlmlr/lazytest'>lazytest</a></span><span class='o'>)</span></span></pre>
 
-The goal of lazytest is to save development time by helping you rerun only the tests that have failed during the last run. It integrates tightly with the testthat package and provides the [`lazytest_local()`](https://krlmlr.github.io/lazytest/reference/lazytest_local.html) function, a drop-in replacement for [`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html), that memoizes the tests that have failed and runs only those tests in subsequent runs. If all active tests have succeeded, the entire test suite is run in a second pass.
+The goal of lazytest is to save development time by helping you rerun only the tests that have failed during the last run. It integrates tightly with the testthat package and provides the [`lazytest_local()`](https://rdrr.io/pkg/lazytest/man/lazytest_local.html) function, a drop-in replacement for [`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html), that
+
+- memoizes which tests have failed;
+- runs only those tests in subsequent runs.
+
+If all active tests have succeeded, the entire test suite is run in a second pass.
 
 ## Usage
 
-Call [`lazytest_local()`](https://krlmlr.github.io/lazytest/reference/lazytest_local.html) in lieu of [`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html) or [`devtools::test()`](https://devtools.r-lib.org/reference/test.html):
+Call [`lazytest_local()`](https://rdrr.io/pkg/lazytest/man/lazytest_local.html) instead of [`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html) or [`devtools::test()`](https://devtools.r-lib.org/reference/test.html):
 
 <pre class='chroma'>
-<span><span class='nf'>lazytest</span><span class='nf'>::</span><span class='nf'><a href='https://krlmlr.github.io/lazytest/reference/lazytest_local.html'>lazytest_local</a></span><span class='o'>(</span><span class='o'>)</span></span></pre>
+<span><span class='nf'>lazytest</span><span class='nf'>::</span><span class='nf'><a href='https://rdrr.io/pkg/lazytest/man/lazytest_local.html'>lazytest_local</a></span><span class='o'>(</span><span class='o'>)</span></span></pre>
 
 The package also provides RStudio add-ins that run the tests in a new terminal. Unfortunately, the “Test package” command is hard-wired to [`devtools::test()`](https://devtools.r-lib.org/reference/test.html), and there seems to be no way to customize it or hook into it.
 
 ## How does it work?
 
-[`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html) returns an object from which the tests that have failed can be retrieved. [`lazytest_local()`](https://krlmlr.github.io/lazytest/reference/lazytest_local.html) wraps this function. If tests have failed, a file named `.lazytest` is written in the package directory. In the next call, if `.lazytest` exists, it is consulted, and a suitable `filter` argument is constructed and passed to [`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html).
+[`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html) returns an object from which the tests that have failed can be retrieved. [`lazytest_local()`](https://rdrr.io/pkg/lazytest/man/lazytest_local.html) wraps this function. If tests have failed, a file named `.lazytest` is written in the package directory. In the next call, if `.lazytest` exists, it is consulted, and a suitable `filter` argument is constructed and passed to [`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html).
 
 When all tests have passed and not all tests were run, a second call to [`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html) is initiated, to make sure that no failures have been introduced in the meantime.
 
-## Installation
+## Installation and optional setup
 
-You can install the development version of lazytest like so:
+You can install the development version of lazytest from [cynkra R-universe](https://cynkra.r-universe.dev/):
+
+<pre class='chroma'>
+<span><span class='nf'><a href='https://rdrr.io/r/utils/install.packages.html'>install.packages</a></span><span class='o'>(</span><span class='s'>'lazytest'</span>, repos <span class='o'>=</span> <span class='nf'><a href='https://rdrr.io/r/base/c.html'>c</a></span><span class='o'>(</span><span class='s'>'https://cynkra.r-universe.dev'</span>, <span class='s'>'https://cloud.r-project.org'</span><span class='o'>)</span><span class='o'>)</span></span></pre>
+
+Or from GitHub:
 
 <pre class='chroma'>
 <span><span class='nf'>pak</span><span class='nf'>::</span><span class='nf'><a href='http://pak.r-lib.org/reference/pak.html'>pak</a></span><span class='o'>(</span><span class='s'>"krlmlr/lazytest"</span><span class='o'>)</span></span></pre>


### PR DESCRIPTION
- add a list in block of text for readability;
- replace "in lieu of" with "instead of" as I suspect the latter is more known (I do like the French-ish version though, of course);
- add installation instructions from R-universe.